### PR TITLE
Adding slash to end of path in Dockerfile so multiple CSVs can be copied

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM robotastic/trunk-recorder:latest
 RUN mkdir -p /app/media
 RUN mkdir -p /app/config
 
-COPY *.csv /app
+COPY *.csv /app/
 
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8


### PR DESCRIPTION
The syntax used for `COPY` does not work if multiple talkgroup CSVs exist in the root directory, Docker will give an error about how a trailing slash is needed. Thus, to prevent this build error if multiple CSVs do exist, I am adding a trailing slash.