### PR TITLE
Updating install instructions to reflect new config directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ Unforunately, this only works with Docker for Linux. As far as I know, there is 
 * [Docker](https://docs.docker.com/engine/installation/linux/ubuntulinux/)
 * [Docker Compose](https://docs.docker.com/compose/install/)
 
-### Install
+### Getting Started
 1. Clone or download this repo
-2. Create a config.json file in the main directory. There are examples in the `.\examples` directory and an explation of the settings [here](https://github.com/robotastic/trunk-recorder/blob/master/README.md).
-3. Add a talkgroup file, if you are using one. Again example in the  `.\examples` directory and an explation of the file [here](https://github.com/robotastic/trunk-recorder/blob/master/README.md).
+2. Create a `config.json` file in the [`./config`](config/) directory. There are examples in the [`./examples`](examples/) directory and an explation of the settings [here](https://github.com/robotastic/trunk-recorder/blob/master/README.md).
+3. Add a talkgroup file in the main (root) directory, if you are using one. You must have at least one `.csv` file present for the Docker container to build, so if you are not using one then just make an empty file. Again example in the [`./examples`](examples/) directory and an explation of the file [here](https://github.com/robotastic/trunk-recorder/blob/master/README.md).
 4. `docker-compose build`
 5. `docker-compose up`
 
-## Updating config
-When you make a change to the `config.json` file you need to update the Docker container. Just run `docker-compose build` to do that.
+## Updating config or talkgroups
+When you make a change to the `config.json` file you need to restart the Docker container. Just run `docker-compose restart` to do that. However, if you update a `.csv` file, you will need to run `docker-compose build` for the container to rebuild to pick up the new talkgroups.


### PR DESCRIPTION
Due to the changes introduced by https://github.com/robotastic/trunk-recorder-docker/pull/2 and subsequent commits, the actual project docker-compose.yml required having a config folder, while the docs still was under the impression of using a single config file in the main folder.

This README change makes a couple improvements to reference the new config directory, as well as note some other changes to the build process as a result. I renamed the heading from Install to Getting Started since someone isn't necessarily installing anything, but configuring the repo with their own settings to get started with trunk-recorder.

The links to the config folder depend on https://github.com/robotastic/trunk-recorder-docker/pull/3.